### PR TITLE
Updated rule: `at-rule-empty-line-before`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# #HEAD
+
+* Updated rule: `at-rule-empty-line-before` with option `ignore: ["after-comment"],`
+
 # 0.2.0
 
 * Fixed: No quotes for URLs -> `"function-url-quotes": [ 2, "none" ]`

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   "rules": {
     "at-rule-empty-line-before": [ 2, "always", {
       except: ["blockless-group"],
+      ignore: ["after-comment"],
     } ],
     "at-rule-no-vendor-prefix": 2,
     "block-closing-brace-newline-after": [ 2, "always" ],


### PR DESCRIPTION
Updated rule: `at-rule-empty-line-before` with option `ignore:
["after-comment"],`