### PR TITLE
Updated rule: `declaration-colon-space-after`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # #HEAD
 
 * Updated rule: `at-rule-empty-line-before` with option `ignore: ["after-comment"],`
+* Updated rule: `declaration-colon-space-after` with option `always-single-line`
 * Added rule: `declaration-colon-newline-after` with option `always-multi-line`
 * Added rule: `function-linear-gradient-no-nonstandard-direction`
 * Bump Stylelint dependency to `1.2.1` to support new rules and options

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     "declaration-block-semicolon-newline-after": [ 2, "always" ],
     "declaration-block-semicolon-space-before": [ 2, "never" ],
     "declaration-colon-newline-after": [ 2, "always-multi-line" ],
-    "declaration-colon-space-after": [ 2, "always" ],
+    "declaration-colon-space-after": [ 2, "always-single-line" ],
     "declaration-colon-space-before": [ 2, "never" ],
     "function-calc-no-unspaced-operator": 2,
     "function-comma-space-after": [ 2, "always" ],


### PR DESCRIPTION
Updated rule: `declaration-colon-space-after` with option `always-single-line`